### PR TITLE
feat: add last record endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Frontend `http://localhost:5173` adresinde çalışacak.
 - **GET** `/api/barcodes/list` - Tüm kayıtları listele
 - **GET** `/api/barcodes/count` - Toplam ürün sayısını getir
 - **GET** `/api/barcodes/stats` - Günlük istatistikleri getir
+- **GET** `/api/barcodes/last` - Son kaydedilen ürünü getir
 - **GET** `/api/barcodes` - CSV dosyasını indir
 - **POST** `/api/barcodes/recreate-csv` - CSV dosyasını yeniden oluştur
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,14 @@ This Spring Boot module provides REST endpoints for saving and retrieving scanne
   - Returns the accumulated records as a CSV file download.
 - `GET /api/barcodes/list`
   - Returns the raw CSV lines as JSON for quick inspection.
+- `GET /api/barcodes/count`
+  - Returns the number of stored records.
+- `GET /api/barcodes/stats`
+  - Returns daily statistics like average duration and over/under counts.
+- `GET /api/barcodes/last`
+  - Returns the last recorded product as JSON.
+- `POST /api/barcodes/recreate-csv`
+  - Rewrites the CSV file with consistent formatting.
 
 ## Building
 ```bash

--- a/backend/src/main/java/com/example/backend/controller/BarcodeController.java
+++ b/backend/src/main/java/com/example/backend/controller/BarcodeController.java
@@ -94,6 +94,17 @@ public class BarcodeController {
         }
     }
 
+    @GetMapping("/last")
+    public ResponseEntity<ProductRecord> getLastRecord() {
+        try {
+            return service.getLastRecord()
+                    .map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.noContent().build());
+        } catch (IOException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
     @PostMapping("/recreate-csv")
     public ResponseEntity<Map<String, String>> recreateCsvFile() {
         try {

--- a/backend/src/main/java/com/example/backend/service/TrackingService.java
+++ b/backend/src/main/java/com/example/backend/service/TrackingService.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.LocalDate;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -61,6 +62,27 @@ public class TrackingService {
 
     public Path getFilePath() {
         return filePath;
+    }
+
+    public Optional<ProductRecord> getLastRecord() throws IOException {
+        List<String> lines = getAllLines();
+        if (lines.size() <= 1) {
+            return Optional.empty();
+        }
+        String line = lines.get(lines.size() - 1);
+        try {
+            String cleanLine = line.replaceAll("\"", "");
+            String[] parts = cleanLine.split(",");
+            if (parts.length >= 3) {
+                String barcode = parts[0];
+                long duration = Long.parseLong(parts[1]);
+                Instant timestamp = Instant.parse(parts[2]);
+                return Optional.of(new ProductRecord(barcode, duration, timestamp));
+            }
+        } catch (Exception e) {
+            // ignore invalid line
+        }
+        return Optional.empty();
     }
 
     public Map<String, Object> getDailyStats() throws IOException {

--- a/backend/src/test/java/com/example/backend/TrackingServiceTest.java
+++ b/backend/src/test/java/com/example/backend/TrackingServiceTest.java
@@ -21,7 +21,18 @@ public class TrackingServiceTest {
         ProductRecord record = new ProductRecord("ABC", 123L, Instant.parse("2024-01-01T00:00:00Z"));
         service.appendRecord(record);
         List<String> lines = Files.readAllLines(temp);
-        assertEquals("barcode,duration,timestamp", lines.get(0));
-        assertTrue(lines.get(1).startsWith("ABC,123"));
+        assertEquals("Barkod,Süre (sn),Zaman Damgası", lines.get(0));
+        assertEquals("\"ABC\",123,\"2024-01-01T00:00:00Z\"", lines.get(1));
+    }
+
+    @Test
+    void returnsLastRecord() throws IOException {
+        Path temp = Files.createTempFile("records", ".csv");
+        TrackingService service = new TrackingService(temp);
+        ProductRecord first = new ProductRecord("ABC", 100L, Instant.parse("2024-01-01T00:00:00Z"));
+        ProductRecord last = new ProductRecord("XYZ", 150L, Instant.parse("2024-01-01T00:05:00Z"));
+        service.appendRecord(first);
+        service.appendRecord(last);
+        assertEquals(last, service.getLastRecord().orElse(null));
     }
 }


### PR DESCRIPTION
## Summary
- allow backend to expose the last recorded product
- document last-record API in READMEs
- test CSV output and last record retrieval

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1024075483328ba0c16acdfc4f9c